### PR TITLE
MINOR: make sure all fiedls of o.p.k.s.a.Action are NOT null (#10764)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/server/authorizer/Action.java
+++ b/clients/src/main/java/org/apache/kafka/server/authorizer/Action.java
@@ -31,27 +31,32 @@ public class Action {
     private final boolean logIfAllowed;
     private final boolean logIfDenied;
 
+    /**
+     * @param operation non-null operation being performed
+     * @param resourcePattern non-null resource pattern on which this action is being performed
+     */
     public Action(AclOperation operation,
                   ResourcePattern resourcePattern,
                   int resourceReferenceCount,
                   boolean logIfAllowed,
                   boolean logIfDenied) {
-        this.operation = operation;
-        this.resourcePattern = resourcePattern;
+        this.operation = Objects.requireNonNull(operation, "operation can't be null");
+        this.resourcePattern = Objects.requireNonNull(resourcePattern, "resourcePattern can't be null");
         this.logIfAllowed = logIfAllowed;
         this.logIfDenied = logIfDenied;
         this.resourceReferenceCount = resourceReferenceCount;
     }
 
     /**
-     * Resource on which action is being performed.
+     * @return a non-null resource pattern on which this action is being performed
      */
     public ResourcePattern resourcePattern() {
         return resourcePattern;
     }
 
     /**
-     * Operation being performed.
+     *
+     * @return a non-null operation being performed
      */
     public AclOperation operation() {
         return operation;


### PR DESCRIPTION
I'm migrating Ranger's kafka plugin from deprecated Authorizer (this is already removed by 976e78e) to new API (see https://issues.apache.org/jira/browse/RANGER-3231). The kafka plugin needs to take something from field resourcePattern but it does not know whether the field is nullable (or users need to add null check). I check all usages and I don't observe any null case.

Reviewers: Ismael Juma <ismael@juma.me.uk>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
