### PR TITLE
KAFKA-12515; Feature support should be ignorable in ApiVersion respon…

### DIFF
--- a/clients/src/main/resources/common/message/ApiVersionsResponse.json
+++ b/clients/src/main/resources/common/message/ApiVersionsResponse.json
@@ -43,7 +43,7 @@
     ]},
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name":  "SupportedFeatures", "type": "[]SupportedFeatureKey",
+    { "name":  "SupportedFeatures", "type": "[]SupportedFeatureKey", "ignorable": true,
       "versions":  "3+", "tag": 0, "taggedVersions": "3+",
       "about": "Features supported by the broker.",
       "fields":  [
@@ -58,7 +58,7 @@
     { "name": "FinalizedFeaturesEpoch", "type": "int64", "versions": "3+",
       "tag": 1, "taggedVersions": "3+", "default": "-1", "ignorable": true,
       "about": "The monotonically increasing epoch for the finalized features information. Valid values are >= 0. A value of -1 is special and represents unknown epoch."},
-    { "name":  "FinalizedFeatures", "type": "[]FinalizedFeatureKey",
+    { "name":  "FinalizedFeatures", "type": "[]FinalizedFeatureKey", "ignorable": true,
       "versions":  "3+", "tag": 2, "taggedVersions": "3+",
       "about": "List of cluster-wide finalized features. The information is valid only if FinalizedFeaturesEpoch >= 0.",
       "fields":  [


### PR DESCRIPTION
…se (#10377)

Feature support should be treated as ignorable in the api version response so that we can gracefully downgrade for older clients without additional logic in the broker.

Reviewers: Rajini Sivaram <rajinisivaram@googlemail.com>, Jason Gustafson <jason@confluent.io>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
